### PR TITLE
Fix type aliasing for higher mypy versions

### DIFF
--- a/resource/_imports.pyi.em
+++ b/resource/_imports.pyi.em
@@ -11,7 +11,7 @@ import typing
 if sys.version_info < (3, 10):
     from typing_extensions import TypeAlias
 else:
-    from typing import TypeAlias
+    from typing import Type as TypeAlias
 
 import array
 import numpy as np


### PR DESCRIPTION
Previously the emitted python code imported `typing.TypeAlias` and defined scoped message types like:


_my_service.pyi
```python
class MyService(metaclass=Metaclass_MyService:
    Request: TypeAlias[MyService_Request] = MyService_Request
    Response: TypeAlias[MyService_Response] = MyService_Response
```

This is fine, and supports typing for direct access: 
```python
req= MyService.Request() # Type understood as MyService_Request
```

But it doesn't support Protocol Generics for nested type extraction:
```python

T = TypeVar('T')
K = TypeVar('K')

class Service(Generic[T, K], Protocol):
    Request: T
    Response: K

# Incompatible types in assignment 
# (expression has type "type[SubmitPrompt]", variable has type "type[Service[Any, Any]]")
S: type[Service] = MyServiceType 
```

Whether this is a mypy bug or not is unknown to me.

However, if we instead use:
```python

class MyService(metaclass=Metaclass_MyService:
    Request: type[MyService_Request] = MyService_Request
    Response: type[MyService_Response] = MyService_Response
```

We get the desired behavior:
```python

S: type[Service] = MyServiceType
S.Request     # type[SubmitPrompt_Request]
S.Response    # type[SubmitPrompt_Response]
```


This allows us to extract type information robustly with generic wrappers.

